### PR TITLE
ゲスト: 招待画面の作成

### DIFF
--- a/app/guest/[roomId]/page.tsx
+++ b/app/guest/[roomId]/page.tsx
@@ -1,20 +1,16 @@
 import UserForm from "@/components/user-form";
 
-const GuestRoomIdPage = ({
-    params
-}: {
-    params: { roomId: string }
-}) => {
-    return (
-        <main className="flex h-full justify-center items-center">
-            <div className="flex flex-col items-center justify-center space-y-14">
-                <h2 className="text-3xl font-bold text-center">
-                    <span>{"[部屋の名前]"}</span>部屋に招待されました
-                </h2>
-                <UserForm />
-            </div>
-        </main>
-    );
-}
- 
+const GuestRoomIdPage = ({ params }: { params: { roomId: string } }) => {
+  return (
+    <main className="flex h-full justify-center items-center">
+      <div className="flex flex-col items-center justify-center space-y-14">
+        <h2 className="text-3xl font-bold text-center">
+          <span>{"[部屋の名前]"}</span>部屋に招待されました
+        </h2>
+        <UserForm />
+      </div>
+    </main>
+  );
+};
+
 export default GuestRoomIdPage;

--- a/app/guest/[roomId]/page.tsx
+++ b/app/guest/[roomId]/page.tsx
@@ -2,7 +2,7 @@ import UserForm from "@/components/user-form";
 
 const GuestRoomIdPage = ({ params }: { params: { roomId: string } }) => {
   /** TODO: roomIdから部屋の名前を取得する処理 */
-  console.log(params)
+  console.log(params);
   return (
     <main className="flex h-full justify-center items-center">
       <div className="flex flex-col items-center justify-center space-y-14">

--- a/app/guest/[roomId]/page.tsx
+++ b/app/guest/[roomId]/page.tsx
@@ -1,0 +1,20 @@
+import UserForm from "@/components/user-form";
+
+const GuestRoomIdPage = ({
+    params
+}: {
+    params: { roomId: string }
+}) => {
+    return (
+        <main className="flex h-full justify-center items-center">
+            <div className="flex flex-col items-center justify-center space-y-14">
+                <h2 className="text-3xl font-bold text-center">
+                    <span>{"[部屋の名前]"}</span>部屋に招待されました
+                </h2>
+                <UserForm />
+            </div>
+        </main>
+    );
+}
+ 
+export default GuestRoomIdPage;

--- a/app/guest/[roomId]/page.tsx
+++ b/app/guest/[roomId]/page.tsx
@@ -2,6 +2,7 @@ import UserForm from "@/components/user-form";
 
 const GuestRoomIdPage = ({ params }: { params: { roomId: string } }) => {
   /** TODO: roomIdから部屋の名前を取得する処理 */
+  console.log(params)
   return (
     <main className="flex h-full justify-center items-center">
       <div className="flex flex-col items-center justify-center space-y-14">

--- a/app/guest/[roomId]/page.tsx
+++ b/app/guest/[roomId]/page.tsx
@@ -1,6 +1,7 @@
 import UserForm from "@/components/user-form";
 
 const GuestRoomIdPage = ({ params }: { params: { roomId: string } }) => {
+  /** TODO: roomIdから部屋の名前を取得する処理 */
   return (
     <main className="flex h-full justify-center items-center">
       <div className="flex flex-col items-center justify-center space-y-14">

--- a/components/user-form.tsx
+++ b/components/user-form.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "./ui/button";
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(1, {
+      message: "名前を入力してください。",
+    })
+    .max(50),
+});
+
+const UserForm = () => {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: "",
+    },
+  });
+
+  const onSubmit = (values: z.infer<typeof formSchema>) => {
+    // TODO: API request
+
+    /** {name: string} */
+    console.log(values);
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-10 w-full flex flex-col"
+      >
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem className="space-y-10 flex flex-col">
+              <FormLabel className="text-center text-2xl font-semibold">
+                あなたのニックネームは？
+              </FormLabel>
+              <FormControl>
+                <Input className="w-full" placeholder="kokoro" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" variant="outline">
+          決定
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+export default UserForm;


### PR DESCRIPTION
## 概要
ホストが送信したURLにゲストがアクセスすると表示される画面を作成。ニックネームを入力することができる。

## 関連issue
[issue8:ゲスト: 招待画面の作成](https://github.com/ni4120/geek-camp/issues/8)

## 影響範囲
なし

## レビュー観点
ニックネーム入力のバリデーションと、コンソールにvalueが表示されるかどうか？

## 補足
この画面はホストが作成した共有URLをクリックすると表示される画面です。