### PR TITLE
RoomUsersテーブルの作成

### DIFF
--- a/prisma/migrations/20241102052626_add_room_user_table/migration.sql
+++ b/prisma/migrations/20241102052626_add_room_user_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "RoomUsers" (
+    "id" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "roomId" UUID NOT NULL,
+
+    CONSTRAINT "RoomUsers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RoomUsers_roomId_userId_key" ON "RoomUsers"("roomId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "RoomUsers" ADD CONSTRAINT "RoomUsers_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "RoomUsers" ADD CONSTRAINT "RoomUsers_roomId_fkey" FOREIGN KEY ("roomId") REFERENCES "Rooms"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   name String
   role Role
   room Rooms? @relation("UserToRoom")
+  roomUsers RoomUsers[] @relation("UserRoomUsers")
 }
 
 enum Role {
@@ -34,10 +35,21 @@ model Rooms {
   name       String
   sharedUrl  String
   status     RoomStatus @default(WAITING)
+  roomUsers RoomUsers[] @relation("RoomRoomUsers")
 }
 
 enum RoomStatus {
   WAITING
   IN_PROGRESS
   COMPLETED
+}
+
+model RoomUsers {
+  id      String  @id @default(uuid()) @db.Uuid
+  userId String  @db.Uuid
+  roomId String  @db.Uuid
+  user    User    @relation("UserRoomUsers",fields: [userId], references: [id])
+  room    Rooms    @relation("RoomRoomUsers",fields: [roomId], references: [id])
+
+  @@unique([roomId, userId])
 }


### PR DESCRIPTION
## 概要
RoomUsersテーブルの追加

## 関連issue
room_usersテーブルの作成 #10

## 補足
このテーブルは待機画面の参加者一覧で参照、ゲーム画面での参加者を表示するために用いる
