### PR TITLE
回答内容と完了ステータスを更新するPATCH APIを追加

### DIFF
--- a/app/api/answers/[answerId]/route.ts
+++ b/app/api/answers/[answerId]/route.ts
@@ -22,7 +22,7 @@ export async function PATCH(
     });
 
     return NextResponse.json(updatedAnswer, { status: 200 });
-  } catch (error) {
+  } catch {
     return NextResponse.json(
       { error: "Failed to update answer" },
       { status: 500 },

--- a/app/api/answers/[answerId]/route.ts
+++ b/app/api/answers/[answerId]/route.ts
@@ -1,0 +1,31 @@
+import { db } from "@/lib/db";
+import { NextResponse } from "next/server";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { answerId: string } },
+) {
+  const { answerId } = params;
+  const { content } = await req.json();
+
+  if (!answerId || content === undefined) {
+    return new Response("Missing parameters", { status: 400 });
+  }
+
+  try {
+    const updatedAnswer = await db.answers.update({
+      where: { id: answerId },
+      data: {
+        content,
+        isCompleted: true,
+      },
+    });
+
+    return NextResponse.json(updatedAnswer, { status: 200 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to update answer" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
## 概要
回答内容と完了ステータスを更新するAPIを追加
指定された answerId に対応する回答の内容を更新し、isCompleted フラグを true に更新

## 関連isuue
[Play画面でユーザーがお題を回答した時のformを送信するAPIを作成](https://github.com/ni4120/geek-camp/issues/49)
